### PR TITLE
fix: distribute with --colorScheme flag now has a default behavior.

### DIFF
--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -99,6 +99,10 @@ program
     '[for web] whether to output the svg as handlebars template.'
   )
   .option(
+    '-oned, --outputToOneDirectory',
+    '[for web] whether to output all the svgs to a single directory'
+  )
+  .option(
     '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
   )
   .option(
@@ -160,6 +164,7 @@ program
       options.type,
       options.groupBy === 'category',
       options.outputAsTemplate,
+      options.outputToOneDirectory,
       options.colorScheme,
       options.withEmbeddedImage,
       options.doNotRemoveSuffix

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -41,18 +41,45 @@ export async function distributeSvg(
   for (const icon of icons) {
     LOGGER.debug(`calling distributeSvg on ${icon.iconName}: ${icon.iconPath} with colorScheme: ${colorScheme}`);
     if (!doNotRemoveSuffix && colorScheme.includes('mixed')){
-      LOGGER.warn(`Warning: By default the "-mixed" suffix is trimmed from the file name when distributed to hbs. The file name will be the SAME as the light variant. Use the --doNotRemoveSuffix flag to keep the "-mixed" in the file name.`);
+      LOGGER.debug(`Warning: By default the "-mixed" suffix is trimmed from the file name when distributed to hbs or to one directory. The file name will be the SAME as the light variant. Use the --doNotRemoveSuffix flag to keep the "-mixed" in the file name.`);
     }
 
     const assets = getIconFlavorsByType(icon, 'svg');
-    // Further filter the icons by matching the assets's colorScheme to the commander option --colorScheme
-    let assetsToDistribute = assets.filter(asset => {
-      if (asset.colorScheme) {
-        return colorScheme.includes(asset.colorScheme);
+    // Further filter the icons by matching the assets's colorScheme to the
+    // commander option --colorScheme
+
+    let lightAssets = assets.filter(asset => asset.colorScheme ? asset.colorScheme === 'light' : true); // Light variants can either have colorScheme: `light`, null, or undefined
+    let darkAssets = assets.filter(asset => asset.colorScheme === 'dark');
+    let mixedAssets = assets.filter(asset => asset.colorScheme === 'mixed');
+
+    let assetsToDistribute: Asset[] = [];
+
+    colorScheme.forEach(value => {
+      switch(value) {
+        case 'light': {
+          assetsToDistribute = assetsToDistribute.concat(...lightAssets);
+          break;
+        }
+        case 'dark': {
+          assetsToDistribute = assetsToDistribute.concat(...darkAssets);
+          break;
+        }
+        case 'mixed': {
+          assetsToDistribute = assetsToDistribute.concat(...mixedAssets);
+          break;
+        }
+        case 'default': {
+          if (mixedAssets.length) {
+            assetsToDistribute = assetsToDistribute.concat(...mixedAssets);
+          } else {
+            assetsToDistribute = assetsToDistribute.concat(...lightAssets);
+            assetsToDistribute = assetsToDistribute.concat(...darkAssets);
+          }
+          break;
+        }
       }
-      // Light variants can either have colorScheme: `light`, null, or undefined
-      return colorScheme.includes('light');
-    });
+    })
+
     if (withEmbeddedImage) {
       // filter down to only the assets that contain embedded images in them
       assetsToDistribute = assetsToDistribute.filter(asset => {
@@ -85,14 +112,15 @@ export async function distributeSvg(
       !svgConfig.toSprite
     );
 
+    const destPath =
+        icon.category && groupByCategory
+          ? path.join(outputPath, icon.category)
+          : outputPath;
+
     if (outputAsHbs) {
       try {
         const imageHrefHelper = svgConfig && svgConfig.outputAsHbs && svgConfig.outputAsHbs.imageHrefHelper;
         const pathToTheImageAsset = svgConfig && svgConfig.outputAsHbs && svgConfig.outputAsHbs.pathToTheImageAsset;
-        const destPath =
-        icon.category && groupByCategory
-          ? path.join(outputPath, icon.category)
-          : outputPath;
         await createHbs(assetsToDistribute, destPath, imageHrefHelper, pathToTheImageAsset, doNotRemoveSuffix);
       }
       catch(e) {
@@ -100,11 +128,10 @@ export async function distributeSvg(
       }
     }
     else if (outputToOneDirectory) {
-      const destPath =
-      icon.category && groupByCategory
-        ? path.join(outputPath, icon.category)
-        : outputPath;
-      await copyIconAssetSvgs(icon.iconName, assetsToDistribute, destPath, outputToOneDirectory);
+      // this comes before the check for the sprite config and therefore does
+      // not respect the value of the config.spriteNames and distributes
+      // assets similar to outputAsHbs above
+      await copyIconAssetSvgs(icon.iconName, assetsToDistribute, destPath, true, true);
     }
     else if (iconHasSpriteConfig) {
       // By default, if there is no distribute config, add to the sprite
@@ -126,11 +153,7 @@ export async function distributeSvg(
       // Just copy the files to the output
       // If the groupByCategory flag is available,
       // put them in a folder that matches the icon category
-      const destPath =
-        icon.category && groupByCategory
-          ? path.join(outputPath, icon.category)
-          : outputPath;
-      await copyIconAssetSvgs(icon.iconName, assetsNoSprite, destPath, outputToOneDirectory);
+      await copyIconAssetSvgs(icon.iconName, assetsNoSprite, destPath, false, false);
     }
   }
 
@@ -150,16 +173,20 @@ async function copyIconAssetSvgs(
   iconName: string,
   assets: Asset[],
   outputPath: string,
-  outputToOneDirectory:boolean = false
+  outputToOneDirectory:boolean = false,
+  stripSuffix = true
 ) {
-
   let outputIconDir = outputToOneDirectory ? outputPath : path.join(outputPath, iconName);
 
   await fs.mkdirp(outputIconDir);
   // copy all assets to the output icon directory
   const promises = [];
   for (const asset of assets) {
-    const assetName = outputToOneDirectory ? `${iconName}-${path.basename(asset.getPath())}` : path.basename(asset.getPath());
+    let assetName = outputToOneDirectory ? `${iconName}-${path.basename(asset.getPath())}` : path.basename(asset.getPath());
+    if (stripSuffix) {
+      assetName = assetName.replace(/-mixed.svg$/, '.svg');
+      assetName = assetName.replace(/-with-image/, '')
+    }
     promises.push(
       fs.copy(
         asset.getPath(),

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -25,6 +25,7 @@ export async function distributeByType(
   type: ICON_TYPES = 'all',
   groupByCategory = true,
   outputAsHbs = false,
+  outputToOneDirectory= false,
   colorScheme: string[] = ['light', 'dark'],
   withEmbeddedImage = false,
   doNotRemoveSuffix = false
@@ -41,13 +42,13 @@ export async function distributeByType(
       break;
     }
     case 'svg': {
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme, withEmbeddedImage, doNotRemoveSuffix);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, outputToOneDirectory, colorScheme, withEmbeddedImage, doNotRemoveSuffix);
       break;
     }
     default: {
       await createImageSet(iconSet, outputPath);
       await distributeByResolution(iconSet, outputPath);
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme, withEmbeddedImage, doNotRemoveSuffix);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, outputToOneDirectory, colorScheme, withEmbeddedImage, doNotRemoveSuffix);
     }
   }
 }

--- a/packages/@icon-magic/distribute/test/index-test.ts
+++ b/packages/@icon-magic/distribute/test/index-test.ts
@@ -15,7 +15,7 @@ const iconSet = configReader.getIconConfigSet(new Array(input));
 describe('distribute works as expected', function () {
   it('Moves all -with-image.svg files to the right output directory', async () => {
     const iconSetAnimal = configReader.getIconConfigSet(new Array(path.resolve(FIXTURES, 'input/animal-with-embedded-images')));
-    await distributeByType(iconSetAnimal, output, 'svg', true, false, ['light', 'dark'], true);
+    await distributeByType(iconSetAnimal, output, 'svg', true, false, false, ['light', 'dark'], true);
     try {
       const files = fs.readdirSync(`${output}/its-ui-with-embedded-images/animal`);
       assert.ok(files.includes('small.svg'));
@@ -423,7 +423,7 @@ describe('distribute works as expected', function () {
 
   it('it trims "-mixed" from end of hbs file name', async () => {
     const iconSetWordmark = configReader.getIconConfigSet(new Array(path.resolve(FIXTURES, 'input/wordmark')));
-    await distributeByType(iconSetWordmark, `${output}/wordmark`, 'svg', false, true, ['mixed'], false);
+    await distributeByType(iconSetWordmark, `${output}/wordmark`, 'svg', false, false, true, ['mixed'], false);
     try {
       const files = fs.readdirSync(`${output}/wordmark`);
       assert.ok(files.includes('wordmark-large.hbs'));
@@ -435,7 +435,7 @@ describe('distribute works as expected', function () {
 
   it('it does not trim "-mixed" from end of hbs file name', async () => {
     const iconSetWordmark = configReader.getIconConfigSet(new Array(path.resolve(FIXTURES, 'input/wordmark')));
-    await distributeByType(iconSetWordmark, `${output}/wordmark/untrimmed`, 'svg', false, true, ['mixed'], true);
+    await distributeByType(iconSetWordmark, `${output}/wordmark/untrimmed`, 'svg', false, false, true, ['mixed'], true);
     try {
       const files = fs.readdirSync(`${output}/wordmark/untrimmed`);
       assert.ok(files.includes('wordmark-large-mixed.hbs'));


### PR DESCRIPTION
fix: distribute with --colorScheme flag now has a default behavior.
- It distributes the mixed assets when present, otherwise defaults to the light and dark assets
- (Using -c mixed light only worked previously because the -mixed asset was overriding the light asset as it had the same name)
- This fix also slightly changes the behavior of the --withImage flag, in that it now acts as a switch. If it is not present, it only distributes assets without an image by default. (The assumption here is that you won't need both versions of an asset at the same time)