### PR TITLE
fix: Removing paralellization of the chrome instance creations.

### DIFF
--- a/packages/@icon-magic/svg-to-png/src/browserPool.ts
+++ b/packages/@icon-magic/svg-to-png/src/browserPool.ts
@@ -53,7 +53,6 @@ process.on('exit', clean);
 //catches ctrl+c event
 process.on('SIGINT', clean);
 process.on('SIGABRT', clean);
-process.on('SIGKILL', clean);
 
 // catches "kill pid" (for example: nodemon restart)
 process.on('SIGUSR1', clean);

--- a/packages/@icon-magic/svg-to-png/src/browserPool.ts
+++ b/packages/@icon-magic/svg-to-png/src/browserPool.ts
@@ -1,9 +1,8 @@
 import * as debug from "debug";
-// import * as os from "os";
 import * as puppeteer from "puppeteer";
 
 const DEBUG = debug('icon-magic:svg-to-png');
-const NUM_CPUS = 1;
+const NUM_CPUS = 1; // should ideally be os.cpus().length - 1 TODO: Investigate more on memory leak issue when this is set
 let WIN_POOL: puppeteer.Browser[] = [];
 let PAGE_POOL: Promise<puppeteer.Page>[] = [];
 let hasBeenInit: false | Promise<boolean> = false;

--- a/packages/@icon-magic/svg-to-png/src/browserPool.ts
+++ b/packages/@icon-magic/svg-to-png/src/browserPool.ts
@@ -1,9 +1,9 @@
 import * as debug from "debug";
-import * as os from "os";
+// import * as os from "os";
 import * as puppeteer from "puppeteer";
 
 const DEBUG = debug('icon-magic:svg-to-png');
-const NUM_CPUS = os.cpus().length - 1;
+const NUM_CPUS = 1;
 let WIN_POOL: puppeteer.Browser[] = [];
 let PAGE_POOL: Promise<puppeteer.Page>[] = [];
 let hasBeenInit: false | Promise<boolean> = false;
@@ -52,6 +52,8 @@ process.on('exit', clean);
 
 //catches ctrl+c event
 process.on('SIGINT', clean);
+process.on('SIGABRT', clean);
+process.on('SIGKILL', clean);
 
 // catches "kill pid" (for example: nodemon restart)
 process.on('SIGUSR1', clean);


### PR DESCRIPTION
This removes the out of memory issue that was being caused by creating too many chromium instances (more than os.cpus().length - 1). browserPool should be instantiated once, but was happening more than once and this is only a quick fix - not the actual solution.  